### PR TITLE
Revisions to support TF Agents training (extremely WIP)

### DIFF
--- a/gym_donkeycar/core/fps.py
+++ b/gym_donkeycar/core/fps.py
@@ -14,6 +14,6 @@ class FPSTimer(object):
         self.iter += 1
         if self.iter == 100:
             e = time.time()
-            print('fps', 100.0 / (e - self.t))
+            #print('fps', 100.0 / (e - self.t))
             self.t = time.time()
             self.iter = 0

--- a/gym_donkeycar/envs/donkey_env.py
+++ b/gym_donkeycar/envs/donkey_env.py
@@ -36,7 +36,7 @@ class DonkeyEnv(gym.Env):
     THROTTLE_MAX = 5.0
     VAL_PER_PIXEL = 255
 
-    def __init__(self, level, time_step=0.05, frame_skip=2):
+    def __init__(self, level, time_step=0.05, frame_skip=2, headless=False):
 
         print("starting DonkeyGym env")
 
@@ -68,7 +68,7 @@ class DonkeyEnv(gym.Env):
             headless = os.environ['DONKEY_SIM_HEADLESS'] == '1'
         except:
             print("Missing DONKEY_SIM_HEADLESS environment var. Using defaults")
-            headless = False
+            headless = headless
 
         logger.info(f'starting DONKEY_SIM_PORT {port}')
         self.proc.start(exe_path, headless=headless, port=port)
@@ -133,23 +133,23 @@ class DonkeyEnv(gym.Env):
 
 class GeneratedRoadsEnv(DonkeyEnv):
 
-    def __init__(self):
-        super(GeneratedRoadsEnv, self).__init__(level=0)
+    def __init__(self, **kwargs):
+        super(GeneratedRoadsEnv, self).__init__(level=0, **kwargs)
 
 
 class WarehouseEnv(DonkeyEnv):
 
-    def __init__(self):
-        super(WarehouseEnv, self).__init__(level=1)
+    def __init__(self, **kwargs):
+        super(WarehouseEnv, self).__init__(level=1, **kwargs)
 
 
 class AvcSparkfunEnv(DonkeyEnv):
 
-    def __init__(self):
-        super(AvcSparkfunEnv, self).__init__(level=2)
+    def __init__(self, **kwargs):
+        super(AvcSparkfunEnv, self).__init__(level=2, **kwargs)
 
 
 class GeneratedTrackEnv(DonkeyEnv):
 
-    def __init__(self):
-        super(GeneratedTrackEnv, self).__init__(level=3)
+    def __init__(self, **kwargs):
+        super(GeneratedTrackEnv, self).__init__(level=3, **kwargs)

--- a/gym_donkeycar/envs/donkey_env.py
+++ b/gym_donkeycar/envs/donkey_env.py
@@ -3,6 +3,7 @@ file: donkey_env.py
 author: Tawn Kramer
 date: 2018-08-31
 '''
+import logging
 import os
 import random
 import time
@@ -14,6 +15,8 @@ from gym.utils import seeding
 from gym_donkeycar.envs.donkey_sim import DonkeyUnitySimContoller
 from gym_donkeycar.envs.donkey_proc import DonkeyUnityProcess
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 class DonkeyEnv(gym.Env):
     """
@@ -24,8 +27,10 @@ class DonkeyEnv(gym.Env):
         "render.modes": ["human", "rgb_array"],
     }
 
-    ACTION_NAMES = ["steer", "throttle"]
-    STEER_LIMIT_LEFT = -1.0
+    # ACTION_NAMES = ["steer", "throttle"]
+    ACTION_NAMES = ["steer"]
+
+    STEER_LIMIT_LEFT = 0
     STEER_LIMIT_RIGHT = 1.0
     THROTTLE_MIN = 0.0
     THROTTLE_MAX = 5.0
@@ -65,6 +70,7 @@ class DonkeyEnv(gym.Env):
             print("Missing DONKEY_SIM_HEADLESS environment var. Using defaults")
             headless = False
 
+        logger.info(f'starting DONKEY_SIM_PORT {port}')
         self.proc.start(exe_path, headless=headless, port=port)
 
         # start simulation com
@@ -72,8 +78,11 @@ class DonkeyEnv(gym.Env):
             level=level, time_step=time_step, port=port)
 
         # steering and throttle
-        self.action_space = spaces.Box(low=np.array([self.STEER_LIMIT_LEFT, self.THROTTLE_MIN]),
-                                       high=np.array([self.STEER_LIMIT_RIGHT, self.THROTTLE_MAX]), dtype=np.float32)
+        self.action_space = spaces.Box(low=np.array([self.STEER_LIMIT_LEFT]),
+                                       high=np.array([self.STEER_LIMIT_RIGHT]), dtype=np.float32)
+
+        # self.action_space = spaces.Box(low=np.array([self.STEER_LIMIT_LEFT, self.THROTTLE_MIN]),
+        #                                high=np.array([self.STEER_LIMIT_RIGHT, self.THROTTLE_MAX]), dtype=np.float32)
 
         # camera sensor data
         self.observation_space = spaces.Box(

--- a/gym_donkeycar/envs/donkey_proc.py
+++ b/gym_donkeycar/envs/donkey_proc.py
@@ -3,9 +3,13 @@ file: donkey_proc.py
 author: Felix Yu
 date: 2018-09-12
 '''
+import logging
 import subprocess
 import os
 
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 class DonkeyUnityProcess(object):
 
@@ -21,6 +25,8 @@ class DonkeyUnityProcess(object):
             return
 
         port_args = ["--port", str(port), '-logFile', 'unitylog.txt']
+
+        logger.info(f'spawning unity subprocess {port_args}')
 
         # Launch Unity environment
         if headless:

--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -85,7 +85,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.sock = None
         self.loaded = False
         self.max_cte = max_cte
-        self.timer = FPSTimer()
+        #self.timer = FPSTimer()
 
         # sensor size - height, width, depth
         self.camera_img_size = cam_resolution
@@ -134,7 +134,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.speed = 0.0
         self.over = False
         self.send_reset_car()
-        self.timer.reset()
+        #self.timer.reset()
         time.sleep(1)
 
     def get_sensor_size(self):
@@ -155,7 +155,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         info = {'pos': (self.x, self.y, self.z), 'cte': self.cte,
                 "speed": self.speed, "hit": self.hit}
 
-        self.timer.on_frame()
+        #self.timer.on_frame()
 
         return observation, reward, done, info
 

--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -20,6 +20,7 @@ from gym_donkeycar.core.tcp_server import IMesgHandler, SimServer
 from gym_donkeycar.envs.donkey_ex import SimFailed
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class DonkeyUnitySimContoller():
@@ -35,10 +36,11 @@ class DonkeyUnitySimContoller():
             level, time_step=time_step, max_cte=max_cte,
             cam_resolution=cam_resolution)
 
+        logger.info(f'Spawning SimServer with address {self.address}')
         try:
             self.server = SimServer(self.address, self.handler)
         except OSError:
-            raise SimFailed("failed to listen on address %s" % self.address)
+            raise SimFailed(f'Failed SimServer with address {self.address}')
 
         self.thread = Thread(target=asyncore.loop)
         self.thread.daemon = True
@@ -139,7 +141,8 @@ class DonkeyUnitySimHandler(IMesgHandler):
         return self.camera_img_size
 
     def take_action(self, action):
-        self.send_control(action[0], action[1])
+        #self.send_control(action[0], action[1])
+        self.send_control(action)
 
     def observe(self):
         while self.last_obs is self.image_array:
@@ -229,7 +232,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
             logger.debug(f"SceneNames: {names}")
             self.send_load_scene(names[self.iSceneToLoad])
 
-    def send_control(self, steer, throttle):
+    def send_control(self, steer, throttle=0.5):
         if not self.loaded:
             return
         msg = {'msg_type': 'control', 'steering': steer.__str__(


### PR DESCRIPTION
TF Agents DQN implementations only supports 1D action specs. This is a sensible default, because it's more difficult to converge on an optimal decision in a multi-variate action space. 

The DonkeyCar gym uses a 2-dimensional action spec, representing [STEER, THROTTLE] values.

ACTION_LOW = [ -1.0, 0.0 ]
ACTION_HIGH = [ 1.0, 5.0 ]

I'm going to experiment with the following:

### Independently train STEER and THROTTLE models

Supply a constant value for THROTTLE and train STEER weights. Then, load STEER weights and use STEER model inferences as a "constant" (non-trainable weight) while training THROTTLE weights. 

I'll train a model for each variable in isolation, then deploy the models in an ensemble.  

Pros:

1. Simpler training algorithm
2. Training will converge on a viable set of weights much faster than a multi-variate problem
3. Decoupling STEER and THROTTLE action space would allow for an ensemble of different algorithms.

Cons:

1. Does not represent realistic driving conditions. For example, one could expect that a high delta between STEER values would correlate to a reduction in THROTTLE values (e.g "slow down on a turn")
2. A THIRD model will be required to express the relationship between independently-trained STEER and THROTTLE values, trained using transfer learning 
3. I suspect ensemble decisions will be slower in real-time. Benchmarking needed.

### Implement multi-dimensional DQN TF Agent

Research required